### PR TITLE
Clear Memory Alloc - with nulls

### DIFF
--- a/utils/alloc.c
+++ b/utils/alloc.c
@@ -131,7 +131,7 @@ void nn_alloc_term (void)
 
 void *nn_alloc_ (size_t size)
 {
-    return malloc (size);
+    return calloc (size, sizeof(size_t));
 }
 
 void *nn_realloc (void *ptr, size_t size)


### PR DESCRIPTION
malloc does not zero fill the allocation

``` c
    return malloc (size);
```

calloc initializes the allocation to all zeros’ guaranteeing a \0  at
the end of every message.

``` c
    return calloc (size, sizeof(size_t));
```
