### PR TITLE
reduce allocation by a factor of 4

### DIFF
--- a/utils/alloc.c
+++ b/utils/alloc.c
@@ -56,7 +56,7 @@ void *nn_alloc_ (size_t size, const char *name)
 {
     uint8_t *chunk;
 
-    chunk = calloc (sizeof (struct nn_alloc_hdr) + size, sizeof(size_t));
+    chunk = calloc (sizeof (struct nn_alloc_hdr) + size, sizeof(uint8_t));
     if (!chunk)
         return NULL;
 
@@ -131,7 +131,7 @@ void nn_alloc_term (void)
 
 void *nn_alloc_ (size_t size)
 {
-    return calloc (size, sizeof(size_t));
+    return calloc (size, sizeof(uint8_t));
 }
 
 void *nn_realloc (void *ptr, size_t size)


### PR DESCRIPTION
`unit8_t` instead of `size_t` reduces memory allocation to more appropriate
block size

credit @jnicholls
https://github.com/nanomsg/nanomsg/pull/363#commitcomment-9395496