### PR TITLE
fix regression in global.c

### DIFF
--- a/core/global.c
+++ b/core/global.c
@@ -431,9 +431,7 @@ void *nn_reallocmsg (void *msg, size_t size)
 
 int nn_freemsg (void *msg)
 {
-    if (msg != NULL) {
     nn_chunk_free (msg);
-    } 
     return 0;
 }
 
@@ -469,7 +467,7 @@ struct nn_cmsghdr *nn_cmsg_nxthdr_ (const struct nn_msghdr *mhdr,
     if (headsz + sizeof (struct nn_cmsghdr) > sz ||
           headsz + NN_CMSG_SPACE (next->cmsg_len) > sz)
         return NULL;
-    
+
     /*  Success. */
     return next;
 }

--- a/utils/alloc.c
+++ b/utils/alloc.c
@@ -56,7 +56,7 @@ void *nn_alloc_ (size_t size, const char *name)
 {
     uint8_t *chunk;
 
-    chunk = calloc (sizeof (struct nn_alloc_hdr) + size, sizeof(uint8_t));
+    chunk = malloc (sizeof (struct nn_alloc_hdr) + size);
     if (!chunk)
         return NULL;
 
@@ -131,7 +131,7 @@ void nn_alloc_term (void)
 
 void *nn_alloc_ (size_t size)
 {
-    return calloc (size, sizeof(uint8_t));
+    return malloc (size);
 }
 
 void *nn_realloc (void *ptr, size_t size)


### PR DESCRIPTION
@marchon, I found that when I removed this `if (msg != NULL) {` check in global.c, suddenly all the msg corruption stops: talking about while using `malloc` as the allocation mechanism in nanomsg iOS. 

I did some extra sleuthing and discovered this tonight due to @nickdesaulniers additional review this evening after we made this change to node-nanomsg: https://github.com/nickdesaulniers/node-nanomsg/pull/56#issuecomment-86255793

The `NULL` pointer check seems to be cause of the regression we were seeing.

We're not really calling `free()`, but rather `nn_chunk_free()`, so `NULL` might be safe.

please review when you have a moment and let me know if you're finding the same.